### PR TITLE
Fix typo in Serialization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ public class PersonController {
 ```java
 // bad
 public class Person {
-    privat String firstname;
+    private String firstname;
     private String lastname;
 
     public void setFirstname() {


### PR DESCRIPTION
There is a missing letter e for the `private` keyword in the Serialization section